### PR TITLE
fix: Reverse words kata

### DIFF
--- a/katas/7kyu/reverse-words.js
+++ b/katas/7kyu/reverse-words.js
@@ -1,10 +1,6 @@
-function solution(str, ending) {
-    if (ending === '') return true;
+function reverseWords(str) {
+    const words = str.split(' ');
+    const wordsReverse = words.map(word => word.split('').reverse().join(''));
 
-    const endingLength = ending.length;
-    const strEnd = str.slice(-endingLength);
-
-    if (strEnd === ending) return true;
-
-    return false;
+    return wordsReverse.join(' ');
 }

--- a/katas/7kyu/reverse-words.js
+++ b/katas/7kyu/reverse-words.js
@@ -1,6 +1,6 @@
 function reverseWords(str) {
-    const words = str.split(' ');
+    const words = str.split(/\s/);
     const wordsReverse = words.map(word => word.split('').reverse().join(''));
 
-    return wordsReverse.join(' ');
+    return wordsReverse.join(/\s/);
 }

--- a/katas/7kyu/string-ends-with.js
+++ b/katas/7kyu/string-ends-with.js
@@ -1,8 +1,0 @@
-function solution(str, ending) {
-    if (!ending) return true;
-
-    const endingLength = ending.length;
-    const strEnd = str.slice(-endingLength);
-
-    return strEnd === ending;
-}

--- a/katas/7kyu/string-ends-with.js
+++ b/katas/7kyu/string-ends-with.js
@@ -1,0 +1,10 @@
+function solution(str, ending) {
+    if (ending === '') return true;
+
+    const endingLength = ending.length;
+    const strEnd = str.slice(-endingLength);
+
+    if (strEnd === ending) return true;
+
+    return false;
+}

--- a/katas/7kyu/string-ends-with.js
+++ b/katas/7kyu/string-ends-with.js
@@ -1,10 +1,8 @@
 function solution(str, ending) {
-    if (ending === '') return true;
+    if (!ending) return true;
 
     const endingLength = ending.length;
     const strEnd = str.slice(-endingLength);
 
-    if (strEnd === ending) return true;
-
-    return false;
+    return strEnd === ending;
 }


### PR DESCRIPTION
Complete the function that accepts a string parameter, and reverses each word in the string. All spaces in the string should be retained.

**Examples**
```
"This is an example!" ==> "sihT si na !elpmaxe"
"double  spaces"      ==> "elbuod  secaps"
```

https://www.codewars.com/kata/5259b20d6021e9e14c0010d4/